### PR TITLE
Changes related to new EC elements_not_overlapping

### DIFF
--- a/common/src/web/javascriptPage.html
+++ b/common/src/web/javascriptPage.html
@@ -249,7 +249,7 @@
   Focusable. Will hide when focus is lost.
 </div>
 
-<div style="margin-top: 10px;">
+<div id="clickToShowParent" style="margin-top: 10px;">
   Click actions delayed by 3000ms:
   <div id="clickToShow" onclick="delayedShowHide(3000, true);"
        style="float: left;width: 100px;height:100px;border: 1px solid black;">

--- a/py/selenium/webdriver/support/expected_conditions.py
+++ b/py/selenium/webdriver/support/expected_conditions.py
@@ -386,6 +386,27 @@ def staleness_of(element: WebElement) -> Callable[[Any], bool]:
 
     return _predicate
 
+def elements_not_overlapping(element1: WebElement, element2:WebElement) -> Callable[[Any], bool]:
+    """An Expectation for checking that two elements do not overlap on the DOM
+    
+    elements are WebElement objects
+    """
+
+    def _predicate(_):
+        if staleness_of(element1):
+            return True
+        if staleness_of(element2):
+            return True
+    
+        rect1 = element1.rect
+        rect2 = element2.rect
+        return (rect1['x'] + rect1['width'] < rect2['x'] or
+                rect2['x'] + rect2['width'] < rect1['x'] or
+                rect1['y'] + rect1['height'] < rect2['y'] or
+                rect2['y'] + rect2['height'] < rect1['y'])
+
+    return _predicate
+
 
 def element_to_be_selected(element: WebElement) -> Callable[[Any], bool]:
     """An expectation for checking the selection is selected.

--- a/py/test/selenium/webdriver/common/webdriverwait_tests.py
+++ b/py/test/selenium/webdriver/common/webdriverwait_tests.py
@@ -282,6 +282,23 @@ def test_expected_condition_element_to_be_clickable(driver, pages):
     WebDriverWait(driver, 4.5).until(EC.invisibility_of_element_located((By.ID, "clickToHide")))
     assert element.is_displayed() is False
 
+def test_expected_condition_elements_not_overlapping(driver, pages):
+    pages.load("javascriptPage.html")
+    element1 = driver.find_element(By.ID, 'keyUp')
+    element2 = driver.find_element(By.ID, 'keyDown')
+    WebDriverWait(driver, 1).until(EC.elements_not_overlapping(element1,element2))
+    clickToShow = driver.find_element(By.ID, 'clickToShow')
+    clickToShow.click()
+    WebDriverWait(driver, 5).until(EC.element_to_be_clickable((By.ID, "clickToHide")))
+    element1 = driver.find_element(By.ID, 'clickToHide')
+    element2 = driver.find_element(By.ID, 'clickToShowParent')
+    with pytest.raises(TimeoutException):
+        WebDriverWait(driver, 1).until(EC.elements_not_overlapping(element1,element2))
+    element1.click()
+    WebDriverWait(driver, 5).until(EC.elements_not_overlapping(element1,element2))
+    assert element1.is_displayed() is False
+
+
 
 def test_expected_condition_staleness_of(driver, pages):
     pages.load("dynamicallyModifiedPage.html")


### PR DESCRIPTION
### **User description**
I have added the new expected condition "elements_not_overlapping". This condition checks that two elements are not overlapping on the dom based on their .rect specs.

### Description
1. Created the function elements_not_overlapping. This EC returns true if two WebElements are not overlapping based on their .rect specs or at least one element is stale.
2. Added a pytest test_expected_conditions_elements_not_overlapping to ensure functionality runs as expected
3. Gave the parent div of "clickToShow" and "clickToHide" in JavascriptPage.html the id "clickToShowParent"

### Motivation and Context
This update provides added functionality and checks for cases where two elements overlap in the DOM temporarily. Examples include: elements dynamically overlapping during scrolling, multiple instances of loading screens occurring simultaneously on the page, etc.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://github.com/SeleniumHQ/selenium/blob/trunk/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new expected condition `elements_not_overlapping` to check if two elements do not overlap based on their rectangle specifications.
- Implemented a test case `test_expected_condition_elements_not_overlapping` to ensure the new condition works as expected.
- Updated `javascriptPage.html` to include an `id` attribute for a `div` element to facilitate testing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_conditions.py</strong><dd><code>Add `elements_not_overlapping` expected condition function</code></dd></summary>
<hr>

py/selenium/webdriver/support/expected_conditions.py

<li>Added <code>elements_not_overlapping</code> function to check if two elements do <br>not overlap.<br> <li> The function returns true if either element is stale or if their <br>rectangles do not intersect.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14368/files#diff-42621053a6328eeae47e9df4bcf1329a182b6241dcd1c7ee2900dfc187f9851c">+21/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>javascriptPage.html</strong><dd><code>Add id to div element in javascriptPage.html</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/web/javascriptPage.html

- Added `id` attribute to a `div` element for testing purposes.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14368/files#diff-ae4246f838b956b3a7f202c40e51048b8458bdef5e711ca02afc1d35cfeb26d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webdriverwait_tests.py</strong><dd><code>Add test for `elements_not_overlapping` expected condition</code></dd></summary>
<hr>

py/test/selenium/webdriver/common/webdriverwait_tests.py

<li>Added a test <code>test_expected_condition_elements_not_overlapping</code> to <br>verify the new expected condition.<br> <li> The test checks both non-overlapping and overlapping scenarios.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/selenium/pull/14368/files#diff-cdc0b4528a21c95e4bbede1854baf3eb1580438660127c75e9cca47693bb8691">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

